### PR TITLE
Remove unused dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@
 
 const fp = require('fastify-plugin')
 const fxp = require('fast-xml-parser')
-const qs = require('qs')
 
 const defaults = {
     contentType: ["text/xml", "application/xml", "application/rss+xml"],


### PR DESCRIPTION
Module `qs` is not used. And since it's not present in package.json dependencies, it requires to be installed manually.