### PR TITLE
Handle error from fast-xml-parser

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,15 +33,22 @@ function xmlBodyParserPlugin(fastify, options, next) {
                     payload.removeListener('data', dataListener);
                     payload.removeListener('end', endListener);
                     done(invalidFormat);
-                } else {
-                  done(null, xmlParser.parse(body));
-                }
+              } else {
+                  handleParseXml(body);
+              }
             } else {
-              done(null, xmlParser.parse(body));
+                handleParseXml(body);
             }
         }
         function dataListener(data) {
             body = body + data;
+        }
+        function handleParseXml(body) {
+            try {
+                done(null, xmlParser.parse(body));
+            } catch (err) {
+                done(err);
+            }
         }
     }
 

--- a/index.js
+++ b/index.js
@@ -33,9 +33,12 @@ function xmlBodyParserPlugin(fastify, options, next) {
                     payload.removeListener('data', dataListener);
                     payload.removeListener('end', endListener);
                     done(invalidFormat);
+                } else {
+                  done(null, xmlParser.parse(body));
                 }
+            } else {
+              done(null, xmlParser.parse(body));
             }
-            done(null, xmlParser.parse(body));
         }
         function dataListener(data) {
             body = body + data;


### PR DESCRIPTION
When sending an XML with an open Pi Tag the fastify server crashes. Both with and without validation option. This occurs because `fast-xml-parser` throws an error which is not processed as `done(err)`.

Another issue is that when using `validate: true`, `xmlParser.parse()` is called regardless of the outcome of `XMLValidator.validate()`, hence the `if/else` fix.


Tested posting this xml to the fastify server:
```xml
<example>
  <?
</example>
```

Which produced this error:
```
/home/example-user/example-project/node_modules/fast-xml-parser/src/xmlparser/OrderedObjParser.js:208
        if(!tagData) throw new Error("Pi Tag is not closed.");
                     ^

Error: Pi Tag is not closed.
    at OrderedObjParser.parseXml (/home/example-user/example-project/node_modules/fast-xml-parser/src/xmlparser/OrderedObjParser.js:208:28)
    at XMLParser.parse (/home/example-user/example-project/node_modules/fast-xml-parser/src/xmlparser/XMLParser.js:35:48)
    at IncomingMessage.endListener (/home/example-user/example-project/node_modules/fastify-xml-body-parser/index.js:40:36)
    at IncomingMessage.emit (node:events:402:35)
    at endReadableNT (node:internal/streams/readable:1343:12)
    at processTicksAndRejections (node:internal/process/task_queues:83:21)
```